### PR TITLE
Make miscellaneous small-scale improvements (GraphQL refactor; upload endpoint namespacing; bugfixes)

### DIFF
--- a/client/src/views/WorkspaceDetail.vue
+++ b/client/src/views/WorkspaceDetail.vue
@@ -90,7 +90,7 @@ export default {
       let tableName = response.data.data.table.name;
     },*/
     async loadFile(){
-      let queryType = this.selectType === "newick" ? "batch" : "tree";
+      let queryType = this.selectType === "newick" ? "bulk" : "tree";
       const response = await api().post(`multinet/${queryType}/${this.workspace}/${this.newTable}`,
       this.fileList[0], 
       {

--- a/client/src/views/WorkspaceDetail.vue
+++ b/client/src/views/WorkspaceDetail.vue
@@ -90,7 +90,7 @@ export default {
       let tableName = response.data.data.table.name;
     },*/
     async loadFile(){
-      let queryType = this.selectType === "newick" ? "bulk" : "newick/tree";
+      let queryType = this.selectType === "newick" ? "csv" : "newick";
       const response = await api().post(`multinet/${queryType}/${this.workspace}/${this.newTable}`,
       this.fileList[0], 
       {

--- a/client/src/views/WorkspaceDetail.vue
+++ b/client/src/views/WorkspaceDetail.vue
@@ -90,7 +90,7 @@ export default {
       let tableName = response.data.data.table.name;
     },*/
     async loadFile(){
-      let queryType = this.selectType === "newick" ? "bulk" : "tree";
+      let queryType = this.selectType === "newick" ? "bulk" : "newick/tree";
       const response = await api().post(`multinet/${queryType}/${this.workspace}/${this.newTable}`,
       this.fileList[0], 
       {

--- a/multinet/multinet/__init__.py
+++ b/multinet/multinet/__init__.py
@@ -35,7 +35,9 @@ class MultiNet(Resource):
         self.arango_port = port
         self.route('POST', ('graphql',), self.graphql)
         self.route('POST', ('bulk', ':workspace', ':table'), self.bulk)
-        self.route('POST', ('tree', ':workspace', ':table'), self.tree)
+
+        # Newick tree operations.
+        self.route('POST', ('newick', 'tree', ':workspace', ':table'), self.tree)
 
     @access.public
     @autoDescribeRoute(

--- a/multinet/multinet/__init__.py
+++ b/multinet/multinet/__init__.py
@@ -34,10 +34,10 @@ class MultiNet(Resource):
         self.resourceName = 'multinet'
         self.arango_port = port
         self.route('POST', ('graphql',), self.graphql)
-        self.route('POST', ('bulk', ':workspace', ':table'), self.bulk)
+        self.route('POST', ('csv', ':workspace', ':table'), self.bulk)
 
         # Newick tree operations.
-        self.route('POST', ('newick', 'tree', ':workspace', ':table'), self.tree)
+        self.route('POST', ('newick', ':workspace', ':table'), self.tree)
 
     @access.public
     @autoDescribeRoute(

--- a/multinet/multinet/__init__.py
+++ b/multinet/multinet/__init__.py
@@ -39,6 +39,9 @@ class MultiNet(Resource):
         # Newick tree operations.
         self.route('POST', ('newick', 'tree', ':workspace', ':table'), self.tree)
 
+        # Operations for Juniper application.
+        self.route('POST', ('juniper', 'node'), self.juniper_get_node)
+
     @access.public
     @autoDescribeRoute(
         Description('Receive GraphQL queries')
@@ -123,6 +126,68 @@ class MultiNet(Resource):
         read_tree(None, tree[0])
 
         return dict(edgecount=edgecount, nodecount=nodecount)
+
+    @access.public
+    @autoDescribeRoute(
+        Description('Retrieve data for a single node for use in the Juniper application.')
+        .param('nodeId', 'ID of the node', required=True)
+    )
+    def juniper_get_node(self, params, nodeId=None):
+        final = {}
+
+        query = f'''query {{
+            nodes (workspace: "dblp", graph: "coauth", nodeType: "author", key: "author/{nodeId}") {{
+                total
+                nodes {{
+                    key
+                    type
+                    incoming {{
+                        total
+                        edges (limit: 20) {{
+                            source {{
+                                outgoing {{
+                                  total
+                                }}
+                                properties (keys: ["type", "title", "_key"]) {{
+                                    key
+                                    value
+                                }}
+                            }}
+                        }}
+                    }}
+                    properties (keys: ["type", "name"]) {{
+                        key
+                        value
+                    }}
+                }}
+            }}
+        }}'''
+
+        result = graphql_query(query)
+
+        author = result['data']['nodes']['nodes'][0]
+        props = {val['key']: val['value'] for val in author['properties']}
+
+        author_data = {'graphDegree': author['incoming']['total'],
+                       'label': 'Author',
+                       'title': props['name'],
+                       'uuid': author['key'].split('/')[1]}
+
+        def make_link(link):
+            props = {prop['key']: prop['value'] for prop in link['source']['properties']}
+            return {'source': author_data,
+                    'target': {'graphDegree': link['source']['outgoing']['total'],
+                               'label': 'Article',
+                               'title': props['title'],
+                               'uuid': props['_key']}}
+
+        links = [make_link(l) for l in author['incoming']['edges']]
+        targetNodes = [link['target'] for link in links]
+
+        return {'nodes': [author_data],
+                'links': links,
+                'root': [author['key'].split('/')[1]],
+                'targetNodes': targetNodes}
 
 class GirderPlugin(plugin.GirderPlugin):
     DISPLAY_NAME = 'MultiNet'

--- a/multinet/multinet/__init__.py
+++ b/multinet/multinet/__init__.py
@@ -15,6 +15,19 @@ import uuid
 from .schema import schema
 from . import db
 
+
+def graphql_query(query):
+    result = graphql(schema, query)
+    if result:
+        errors= [error.message for error in result.errors] if result.errors else []
+        logprint("Errors in request: %s" % len(errors), level=logging.WARNING)
+        for error in errors[:10]:
+            logprint(error, level=logging.WARNING)
+    else:
+        errors = []
+    return dict(data=result.data, errors=errors)
+
+
 class MultiNet(Resource):
     def __init__(self, port):
         super(MultiNet, self).__init__()
@@ -34,15 +47,7 @@ class MultiNet(Resource):
         query = getBodyJson()['query']
         logprint('request: %s' % query, level=logging.DEBUG)
 
-        result = graphql(schema, query)
-        if result:
-            errors= [error.message for error in result.errors] if result.errors else []
-            logprint("Errors in request: %s" % len(errors), level=logging.WARNING)
-            for error in errors[:10]:
-                logprint(error, level=logging.WARNING)
-        else:
-            errors = []
-        return dict(data=result.data, errors=errors)
+        return graphql_query(query)
 
     @access.public
     @autoDescribeRoute(

--- a/multinet/multinet/db.py
+++ b/multinet/multinet/db.py
@@ -60,7 +60,11 @@ def nodes(query, cursor, arango=None):
     graph = workspace.graph(query.graph)
     if query.entity_type:
         if query.id:
-            return [Entity(query.workspace, query.graph, query.entity_type, workspace.collection(query.entity_type).get(query.id))], 1
+            result = workspace.collection(query.entity_type).get(query.id)
+            if result is not None:
+                return [Entity(query.workspace, query.graph, query.entity_type, workspace.collection(query.entity_type).get(query.id))], 1
+            else:
+                return [], 0
         else:
             tables = [workspace.collection(query.entity_type)]
     else:

--- a/multinet/multinet/db.py
+++ b/multinet/multinet/db.py
@@ -3,7 +3,7 @@ import os
 from girder import logprint
 from arango import ArangoClient
 
-from multinet.types import Row, Entity
+from multinet.types import Row, Entity, Cursor
 
 def with_client(fun):
     def wrapper(*args, **kwargs):


### PR DESCRIPTION
~This pull request attempts to create a MultiNet endpoint that can be used as a drop-in replacement for the Phovea endpoints currently used by Juniper. Currently, the "get single node" action is implemented, but it works only for Author nodes.~

The PR ~also~ includes some bug fixes:
- a typo in the newick loader
- missing type imports in the GraphQL infrastructure

It also introduces application namespaces within the API. The Newick tree loader is under a `newick` namespace, while the ~Juniper actions will go under a `juniper` namespace~ bulk loader has been renamed to the CSV loader (in the `csv` namespace).