### PR TITLE
Add some convenience scripts via a top-level package.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,7 @@ jobs:
           command: yarn install --frozen-lockfile
       - run:
           name: JavaScript lint tests
-          working_directory: client
-          command: yarn lint
+          command: yarn lint:js
       - save_cache:
           name: Save Yarn package cache
           key: yarn-packages-{{ checksum "client/yarn.lock" }}
@@ -33,8 +32,7 @@ jobs:
           command: pipenv install
       - run:
           name: Python lint tests
-          working_directory: multinet
-          command: pipenv run tox -e flake8 -- --ignore=E501,D100,D101,D102,D103,D104,D107
+          command: yarn lint:py
       - save_cache:
           key: pipenv-{{ checksum "Pipfile.lock" }}
           paths:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,12 +5,12 @@ A Girder plugin proof-of-concept for a MultiNet API / web application
 Installation
 =================
 
-Set Up Girder
-^^^^^^^^^^^^^
+Set Up Multinet/Girder
+^^^^^^^^^^^^^^^^^^^^^^
 1. Clone this repository: ``git clone
    https://github.com/multinet-app/multinet-girder; cd multinet-girder``.
 2. Start the mongo and arango databases using docker-compose:
-   ``MULTINET_APP_PASSWORD=yourSecretPassword docker-compose up -d``.  NOTE:
+   ``MULTINET_ROOT_PASSWORD=yourSecretPassword docker-compose up -d``.  NOTE:
    macOS users may encounter errors in this step regarding filemounts denied to
    the Docker process; to solve this issue, create two directories somewhere
    (e.g. ``mkdir -p ~/.local/multinet/mongo``, ``mkdir -p
@@ -19,15 +19,11 @@ Set Up Girder
    ARANGO_DATA=~/.local/multinet/arango docker-compose up -d``.
 3. Use pipenv to create a virtual environment and install the dependencies:
    ``pipenv install``.
-4. Start the pipenv shell to set up girder and run the websever: ``pipenv shell``.
-5. Build the Girder web client: ``girder build``.
-6. Serve the Girder client: ``MULTINET_APP_PASSWORD=yourSecretPassword girder
-   serve --database mongodb://localhost:27017/multinet --port 9090``.
-7. Open the Girder client and register a user (which will become an admin user):
-   http://localhost:9090.
-8. Click on "Admin Console" in the left sidebar, then "Plugins", then activte
-   the MultiNet plugin, then click the Restart button and wait for the page to
-   reload.
+4. Build the Girder web client: ``pipenv run girder build``.
+5. Start the Multinet server: ``MULTINET_APP_PASSWORD=yourSecretPassword yarn
+   start:server``.
+6. Open the Multinet Girder application and register a user (which will become
+   an admin user): http://localhost:9090.
 
 Run Sample Client
 ^^^^^^^^^^^^^^^^^

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "multinet-girder",
+  "version": "0.1.0",
+  "description": "A Girder plugin proof-of-concept for a MultiNet API / web application",
+  "scripts": {
+    "lint:js": "yarn --cwd client run lint",
+    "lint:py": "cd multinet && pipenv run tox -e flake8 -- --ignore=E501,D100,D101,D102,D103,D104,D107",
+    "start:server": "pipenv run girder serve --database mongodb://localhost:27017/multinet --port 9090",
+    "build:docs": "pipenv run make html -C docs",
+    "serve:docs": "pipenv run python -m http.server -d docs/_build/html",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/multinet-app/multinet-girder.git"
+  },
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/multinet-app/multinet-girder/issues"
+  },
+  "homepage": "https://github.com/multinet-app/multinet-girder#readme"
+}


### PR DESCRIPTION
Try out the scripts via commands like `yarn run lint:py` (or just `yarn lint:py`).

Closes #57 
