### PR TITLE
Connect repository to ReadTheDocs for automated documentation generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,5 @@
 # multinet-girder
 A Girder plugin proof-of-concept for a MultiNet API / web application
 
-## Installation
-
-### Set Up Girder
-1. Clone this repository: `git clone
-   https://github.com/multinet-app/multinet-girder; cd multinet-girder`
-2. Start the mongo and arango databases using docker-compose:
-   `MULTINET_APP_PASSWORD=yourSecretPassword docker-compose up -d` NOTE: macOS
-   users may encounter errors in this step regarding filemounts denied to the
-   Docker process; to solve this issue, create two directories somewhere (e.g.
-   `mkdir -p ~/.local/multinet/mongo`, `mkdir -p ~/.local/multinet/arango`), and
-   launch the Docker container using `MULTINET_APP_PASSWORD=yourSecretPassword
-   MONGO_DATA=~/.local/multinet/mongo ARANGO_DATA=~/.local/multinet/arango
-   docker-compose up -d`.
-3. Use pipenv to create a virtual environment and install the dependencies:
-   `pipenv install`
-4. Start the pipenv shell to set up girder and run the websever: `pipenv shell`
-5. Build the Girder web client: `girder build`
-6. Serve the Girder client: `MULTINET_APP_PASSWORD=yourSecretPassword girder
-   serve --database mongodb://localhost:27017/multinet --port 9090`
-7. Open the Girder client and register a user (which will become an admin user):
-   http://localhost:9090
-8. Click on "Admin Console" in the left sidebar, then "Plugins", then activte
-   the MultiNet plugin, then click the Restart button and wait for the page to
-   reload.
-
-### Run Sample Client
-1. Move into the client code directory: `cd client`
-2. Install dependencies: `yarn install`
-3. Serve the application: `yarn serve`
-4. Visit the sample client by opening the displayed URL (the Vue builder will
-   choose an open port and show you).
+## Documentation
+https://multinet-girder.readthedocs.io/en/latest/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,8 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
+master_doc = 'index'
+
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -1,0 +1,14 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7


### PR DESCRIPTION
See sample documentation at https://multinet-girder.readthedocs.io/en/rtd/ (in general, documentation will appear at https://multinet-girder.readthedocs.io/en/latest/, as noted in the README).

Closes #58.