### PR TITLE
nested_json uploader

### DIFF
--- a/client/src/views/WorkspaceDetail.vue
+++ b/client/src/views/WorkspaceDetail.vue
@@ -196,7 +196,8 @@ export default {
       fileList: [],
       fileTypes: {
         csv: {extension: ['csv'], queryCall: 'csv'},
-        newick: {extension: ['phy', 'tree'], queryCall: 'newick'}
+        newick: {extension: ['phy', 'tree'], queryCall: 'newick'},
+        nested_json: {extension: ['json'], queryCall: 'nested_json'},
       },
       selectedType: null,
       graphNodeTables: [],

--- a/multinet/multinet/__init__.py
+++ b/multinet/multinet/__init__.py
@@ -6,7 +6,6 @@ from girder.api.rest import Resource, getBodyJson
 from girder.api.describe import Description, autoDescribeRoute
 from girder.exceptions import RestException
 
-import arango
 import csv
 from io import StringIO
 import itertools
@@ -292,9 +291,9 @@ class MultiNet(Resource):
         (nodes, edges) = analyze_nested_json(data, int_nodetable_name, leaf_nodetable_name)
 
         # Upload the data to the database.
-        edge_results = edgetable.insert_many(edges)
-        int_node_results = int_nodetable.insert_many(nodes[0])
-        leaf_node_results = leaf_nodetable.insert_many(nodes[1])
+        edgetable.insert_many(edges)
+        int_nodetable.insert_many(nodes[0])
+        leaf_nodetable.insert_many(nodes[1])
 
         return dict(edgecount=len(edges), int_nodecount=len(nodes[0]), leaf_nodecount=len(nodes[1]))
 


### PR DESCRIPTION
This PR adds the ability to upload a nested_json file of a specific type: the uploader creates two node tables (`<name>_internal_nodes` and `<name>_leaf_nodes`) and an edge table (`<name>_edges`), with the assumption that internal nodes have a different shape of data than the leaf nodes do.

This should help us put together a demo using our specific nested_json files, but we'll need to add an extension to arbitrarily sort all the nodes into as many "data shapes" as are found among them.

attn: @jenrogers1207 and @curtislisle